### PR TITLE
Fix the bug in the client-side time

### DIFF
--- a/src/codeu/chat/common/Time.java
+++ b/src/codeu/chat/common/Time.java
@@ -39,7 +39,7 @@ public final class Time implements Comparable<Time> {
     public Time read(InputStream in) throws IOException {
 
       final long high = (long)Serializers.INTEGER.read(in);
-      final long low = (long)Serializers.INTEGER.read(in);
+      final long low = (long)Serializers.INTEGER.read(in) & 0x00000000FFFFFFFFL;
 
       return Time.fromMs((high << 32) | low);
 


### PR DESCRIPTION
The int to long conversion pads with 1s if the int is negative in order to preserve the sign. This change uses a mask to ensure that this padding is done in an unsigned way. This fixes the bug in the time values that causes the creation times for messages and accounts to show 1969 instead of 2017.